### PR TITLE
Modified viewpanel to render views inside the tags that specify them.

### DIFF
--- a/scripted/src/scripts/ui/views/view-panel.js
+++ b/scripted/src/scripts/ui/views/view-panel.js
@@ -99,6 +99,7 @@ Exhibit.ViewPanel.create = function(configuration, div, uiContext) {
             viewPanel._viewLabels.push(label);
             viewPanel._viewTooltips.push(tooltip);
             viewPanel._viewDomConfigs.push(null);
+            viewPanel._viewDoms.push(null);
         }
     }
     
@@ -314,6 +315,7 @@ Exhibit.ViewPanel.prototype._internalValidate = function() {
         this._viewLabels.push(Exhibit._("%TileView.label"));
         this._viewTooltips.push(Exhibit._("%TileView.tooltip"));
         this._viewDomConfigs.push(null);
+        this._viewDoms.push(null);
     }
     
     this._viewIndex = 


### PR DESCRIPTION
Previously, views were rendered in a separately created
"view container" that was not a child of the tag specifying the view.
Thus, attributes specified on the view tag (e.g. classes for styling)
would not apply to the rendered view.  Which made it more difficult
for an author to style those views.  In the new version, the view
container is placed inside the tag that specified the view.

If the selected view was defined programmatically, rather than by a
tag, then the view container is placed as an immediate child of the
view panel tag.

This new approach is still imperfect.  To render a view,
the viewpanel empties the target div, which destroys contextual
information such as lenses intended for the view.  For standalone
views this is ok, as the view is rendered only once.  However, the
viewpanel re-creates a view each time that view is selected; the
second rendering will no longer have the context.  To circumvent this
problem, a new div is created inside the view tag to hold the rendered
view.  Thus, when it is emptied for the next rendering, the remaining
content of the view tag is undisturbed.

On the downside, this means that standalone views render in a slightly
different way than views in viewpanels---those in viewpanels are
nested inside a view container that is not present in standalone
views.  However, this is still a significant improvement over the previous
approach, where the rendered view was not inside the viewtag at all.

Longer-term, it seems beneficial for every view to render its content
inside a newly-created, nested view container div.  This would
provide consistency while still shielding the rendering and the
original specification-content of the view tag from each other.
