### PR TITLE
bugfixed history mechanism

### DIFF
--- a/scripted/src/scripts/ui/views/view-panel.js
+++ b/scripted/src/scripts/ui/views/view-panel.js
@@ -386,6 +386,8 @@ Exhibit.ViewPanel.prototype._createView = function() {
  * @param {Number} newIndex
  */
 Exhibit.ViewPanel.prototype._switchView = function(newIndex) {
+    if (newIndex >=  this._viewConstructors.length)
+        return; //attempt to switch to nonexistent view 
     Exhibit.jQuery(this.getContainer()).trigger(
         "onBeforeViewPanelSwitch.exhibit",
         [ this._viewIndex ]

--- a/scripted/src/scripts/util/history.js
+++ b/scripted/src/scripts/util/history.js
@@ -282,7 +282,7 @@ Exhibit.History.replaceState = function(data, subtitle, url) {
  * @static
  */
 Exhibit.History.eraseState = function() {
-    Exhibit.History.pushState({});
+    Exhibit.History.pushState({"components": {}});
 };
 
 Exhibit.jQuery(document).bind(


### PR DESCRIPTION
eraseState was pushing an invalid empty state
and viewPanel constructor was trying to switch to historic state
index, even if no view with that index actually exists.
