### PR TITLE
Fixed a bug with upper/lower case mismatch in data- attribute lookup.

### DIFF
--- a/scripted/src/scripts/exhibit.js
+++ b/scripted/src/scripts/exhibit.js
@@ -108,7 +108,7 @@ Exhibit.getAttribute = function(elmt, name, splitOn) {
     try {
         value = Exhibit.jQuery(elmt).attr(name);
         if (typeof value === "undefined" || value === null || value.length === 0) {
-            value = Exhibit.jQuery(elmt).data("ex-"+name);
+            value = Exhibit.jQuery(elmt).data("ex-"+name.toLowerCase());
             if (typeof value === "undefined" || value === null || value.length === 0) {
                 return null;
             }


### PR DESCRIPTION
Exhibit 2 attributes used camelcase.  new exhibit code uses as data-ex
prefix and looks up attributes using .data() .  But the spec for data-
attributes says all must be lower case, and they are being forced to
that, so the data- attribute lookup wasn't matching.  Correcting by
forcing attribute name to lowercase before lookup.

Probably the better solution long term is to convert exhibit
attributes names from camelcase to hyphenation; e.g. ex:viewClass
should become data-ex-view-class not data-ex-viewclass .  But that
involves a decision to change exhibit syntax and also requires more
substantial code changes, so I defer it.
