### PR TITLE
History was removing ?query part of the url, which could break

### DIFF
--- a/scripted/src/scripts/util/history.js
+++ b/scripted/src/scripts/util/history.js
@@ -235,7 +235,8 @@ Exhibit.History.pushState = function(data, subtitle) {
             title += " {" + subtitle + "}";
         }
         
-        url = Exhibit.History._originalLocation;
+        //if HTML4 is emulating pushstate, a # in the URL will break it
+        url = document.location.href.replace(/#.*/,"");
         
         History.pushState(data, title, url);
     }


### PR DESCRIPTION
exhibits that are generated on the fly based on a query fragment.
Removing just the hash is sufficient to let history's html4 emulation work.
