### PR TITLE
Modified extension scriptloaders to tolerate firefox active content blocking under https

### DIFF
--- a/scripted/src/extensions/map/map-extension.js
+++ b/scripted/src/extensions/map/map-extension.js
@@ -21,7 +21,9 @@
 (function() {
     var loader;
     loader = function() {
-        var javascriptFiles, cssFiles, paramTypes, url, scriptURLs, cssURLs, ajaxURLs, i, delayID, finishedLoading, localesToLoad;
+        var javascriptFiles, cssFiles, paramTypes, url, scriptURLs, cssURLs, ajaxURLs, i, delayID, finishedLoading, localesToLoad
+        , proto = document.location.protocol === "https:" ?
+            "https:" : "http:";
         delayID = Exhibit.generateDelayID();
         Exhibit.jQuery(document).trigger(
             "delayCreation.exhibit",
@@ -33,7 +35,7 @@
                 "bundle": true,
                 "gmapKey": null,
                 "service": "google",
-                "mapPrefix": "http://api.simile-widgets.org"
+                "mapPrefix": proto + "//api.simile-widgets.org"
             },
             "urlPrefix": null,
             "markerUrlPrefix" :"http://service.simile-widgets.org/painter/painter?",
@@ -96,11 +98,11 @@
         if (Exhibit.MapExtension.params.service === "google2" &&
                    typeof GMap2 === "undefined") {
             if (typeof Exhibit.params.gmapKey !== "undefined") {
-	            scriptURLs.push("http://maps.google.com/maps?file=api&v=2&sensor=false&callback=Exhibit.MapExtension.noop&async=2&key=" + Exhibit.params.gmapKey);
+	            scriptURLs.push(proto + "//maps.google.com/maps?file=api&v=2&sensor=false&callback=Exhibit.MapExtension.noop&async=2&key=" + Exhibit.params.gmapKey);
             } else if (typeof Exhibit.MapExtension.params.gmapKey !== "undefined") {
-	            scriptURLs.push("http://maps.google.com/maps?file=api&v=2&sensor=false&callback=Exhibit.MapExtension.noop&async=2&key=" + Exhibit.MapExtension.params.gmapKey);
+	            scriptURLs.push(proto + "//maps.google.com/maps?file=api&v=2&sensor=false&callback=Exhibit.MapExtension.noop&async=2&key=" + Exhibit.MapExtension.params.gmapKey);
             } else {
-	            scriptURLs.push("http://maps.google.com/maps?file=api&v=2&sensor=false&callback=Exhibit.MapExtension.noop&async=2");
+	            scriptURLs.push(proto + "//maps.google.com/maps?file=api&v=2&sensor=false&callback=Exhibit.MapExtension.noop&async=2");
             }
             if (!Exhibit.MapExtension.params.bundle) {
                 javascriptFiles.push("google-maps-v2-view.js");
@@ -109,7 +111,7 @@
             // if author is referring to an unknown service, default to google
 	        if (typeof google === "undefined" ||
                 (typeof google !== "undefined" && typeof google.map === "undefined")) {
-	            scriptURLs.push("http://maps.googleapis.com/maps/api/js?sensor=false&callback=Exhibit.MapExtension.noop");
+	            scriptURLs.push(proto + "//maps.googleapis.com/maps/api/js?sensor=false&callback=Exhibit.MapExtension.noop");
                 if (!Exhibit.MapExtension.params.bundle) {
                     javascriptFiles.push("map-view.js");
                 }

--- a/scripted/src/extensions/time/time-extension.js
+++ b/scripted/src/extensions/time/time-extension.js
@@ -32,7 +32,9 @@
 (function() {
     var loader;
     loader = function() {
-        var javascriptFiles, cssFiles, paramTypes, url, scriptURLs, cssURLs, ajaxURLs, i, delayID, finishedLoading, localesToLoad;
+        var javascriptFiles, cssFiles, paramTypes, url, scriptURLs, cssURLs, ajaxURLs, i, delayID, finishedLoading, localesToLoad
+        , proto = document.location.protocol === "https:" ?
+            "https:" : "http:";
         delayID = Exhibit.generateDelayID();
         Exhibit.jQuery(document).trigger(
             "delayCreation.exhibit",
@@ -42,7 +44,7 @@
         Exhibit.TimeExtension = {
             "params": {
                 "bundle": true,
-                "timelinePrefix": "http://api.simile-widgets.org",
+                "timelinePrefix": proto + "//api.simile-widgets.org",
                 "timelineVersion": "2.3.1"
             },
             "urlPrefix": null,


### PR DESCRIPTION
firefox has introduced "mixed active content blocking" which means
that an exhibit web page loaded with https will refuse to load http: script
links.  At the top level this can be fixed by a user choosing suitable
relative urls for exhibit scripts
(//api.simile-widgets.org/exhibit/...)  .  However, the map and time
extensions load other scripts whose urls were hard-coded to http.
Fixed by setting these urls to https if the document url is https.
