### PR TITLE
exporter.js assumed self-describing data which broke tsv export.

### DIFF
--- a/scripted/src/scripts/data/exporter.js
+++ b/scripted/src/scripts/data/exporter.js
@@ -100,13 +100,15 @@ Exhibit.Exporter.prototype.getLabel = function() {
  * @param {Exhibit.Database} database
  * @returns {Object}
  */
-Exhibit.Exporter.prototype.exportOneFromDatabase = function(itemID, database) {
-    var allProperties, fn, i, propertyID, property, values, valueType, item;
+Exhibit.Exporter.prototype.exportOneFromDatabase = function(itemID,
+                                                            database, 
+                                                            props) {
+    var fn, prop, values, valueType, item;
 
     fn = function(vt, s) {
         if (vt === "item") {
             return function(value) {
-                s.push(database.getObject(value, "label"));
+                s.push(database.getObject(value, "label") || value);
             };
         } else if (vt === "url") {
             return function(value) {
@@ -115,23 +117,24 @@ Exhibit.Exporter.prototype.exportOneFromDatabase = function(itemID, database) {
         }
     };
 
-    allProperties = database.getAllProperties();
+    props = props || 
+        Exhibit.Exporter._getPropertiesWithValueTypes(database);
     item = {};
 
-    for (i = 0; i < allProperties.length; i++) {
-        propertyID = allProperties[i];
-        property = database.getProperty(propertyID);
-        values = database.getObjects(itemID, propertyID);
-        valueType = property.getValueType();
-
-        if (values.size() > 0) {
-            if (valueType === "item" || valueType === "url") {
-                strings = [];
-                values.visit(fn(valueType, strings));
-            } else {
-                strings = values.toArray();
+    for (prop in props) {
+        if (props.hasOwnProperty(prop)) {
+            values = database.getObjects(itemID, prop);
+            valueType = props[prop].valueType;
+            
+            if (values.size() > 0) {
+                if (valueType === "item" || valueType === "url") {
+                    strings = [];
+                    values.visit(fn(valueType, strings));
+                } else {
+                    strings = values.toArray();
+                }
+                item[prop] = strings;
             }
-            item[propertyID] = strings;
         }
     }
 
@@ -143,14 +146,16 @@ Exhibit.Exporter.prototype.exportOneFromDatabase = function(itemID, database) {
  * @param {Exhibit.Database} database
  * @returns {String}
  */
-Exhibit.Exporter.prototype.exportOne = function(itemID, database) {
+Exhibit.Exporter.prototype.exportOne = function(itemID, database, props) {
+    props = props || Exhibit.Exporter._getPropertiesWithValueTypes(database);
     return this._wrap(
         this._exportOne(
             itemID,
             this.exportOneFromDatabase(itemID, database),
-            Exhibit.Exporter._getPropertiesWithValueTypes(database)
+            props 
         ),
-        database
+        database,
+        props
     );
 };
 
@@ -160,26 +165,28 @@ Exhibit.Exporter.prototype.exportOne = function(itemID, database) {
  * @returns {String}
  */
 Exhibit.Exporter.prototype.exportMany = function(set, database) {
+    var s = "", self = this, count = 0, size = set.size(), props
+    , wraps = [];
+
     if (typeof this._exportMany !== "undefined" && typeof this._exportMany === "function") {
         this.exportMany = this._exportMany;
         return this._exportMany(set, database);
     }
 
-    var s = "", self = this, count = 0, size = set.size(), props;
-
     props = Exhibit.Exporter._getPropertiesWithValueTypes(database);
     set.visit(function(itemID) {
-        s += self._wrapOne(
-            self._exportOne(
-                itemID,
-                self.exportOneFromDatabase(itemID, database),
-                props)
-            ,
-            count === 0,
-            count++ === size - 1
-        );
+        wraps.push( 
+            self._wrapOne(
+                self._exportOne(
+                    itemID,
+                    self.exportOneFromDatabase(itemID, database),
+                    props)
+                ,
+                count === 0,
+                count++ === size - 1
+            ));
     });
-    return this._wrap(s, database);
+    return this._wrap(wraps.join(""), database, props);
 };
 
 /**

--- a/scripted/src/scripts/data/exporters/bibtex.js
+++ b/scripted/src/scripts/data/exporters/bibtex.js
@@ -54,6 +54,9 @@ Exhibit.Exporter.BibTex.exportOne = function(itemID, o) {
 
     if (typeof o.key !== "undefined") {
         key = o.key;
+        if (Array.isArray(key)) {
+            key = key[0];
+        }
     } else {
         key = itemID;
     }

--- a/scripted/src/scripts/data/exporters/tsv.js
+++ b/scripted/src/scripts/data/exporters/tsv.js
@@ -17,20 +17,19 @@ Exhibit.Exporter.TSV = {
  * @param {Exhibit.Database} database
  * @returns {String}
  */
-Exhibit.Exporter.TSV.wrap = function(s, database) {
-    var header, i, allProperties, propertyID, property, valueType;
+Exhibit.Exporter.TSV.wrap = function(s, database, props) {
+    var header, prop, propertyID, property, valueType;
 
-    header = "";
+    header = [];
 
-    allProperties = database.getAllProperties();
-    for (i = 0; i < allProperties.length; i++) {
-        propertyID = allProperties[i];
-        property = database.getProperty(propertyID);
-        valueType = property.getValueType();
-        header += propertyID + ":" + valueType + "\t";
+    for (prop in props) {
+        if (props.hasOwnProperty(prop)) {
+            valueType = props[prop].valueType;
+            header.push(prop + ":" + valueType);
+        }
     }
 
-    return header + "\n" + s;
+    return header.join("\t") + "\n" + s;
 };
 
 /**
@@ -46,16 +45,19 @@ Exhibit.Exporter.TSV.wrapOne = function(s, first, last) {
  * @param {Object} o
  * @returns {String}
  */
-Exhibit.Exporter.TSV.exportOne = function(itemID, o) {
-    var prop, s = "";
+Exhibit.Exporter.TSV.exportOne = function(itemID, o, props) {
+    var prop, s = "", fields=[];
 
-    for (prop in o) {
-        if (o.hasOwnProperty(prop)) {
-            s += o[prop].join("; ") + "\t";
+    for (prop in props) {
+        if (props.hasOwnProperty(prop)) {
+            if (o.hasOwnProperty(prop)) {
+                fields.push(o[prop]);
+            } else {
+                fields.push("");
+            }
         }
     }
-
-    return s;
+    return fields.join("\t");
 };
 
 /**


### PR DESCRIPTION
Tabular data formats require a constistent global (ordered) list of
properties to export.  Modified exporter.js to provide this and tsv.js
to rely on it.  Also fixed a small bibtex.js bug
