### PR TITLE
Warn instead of halting when one component suffers exceptions

### DIFF
--- a/scripted/src/scripts/exhibit.js
+++ b/scripted/src/scripts/exhibit.js
@@ -427,7 +427,7 @@ Exhibit._Impl.prototype.configureFromDOM = function(root) {
             try {
                 Exhibit.UI.createFromDOM(elmt, uiContext);
             } catch (ex1) {
-                Exhibit.Debug.exception(ex1);
+                Exhibit.Debug.warn(ex1);
             }
         }
     };


### PR DESCRIPTION
Previously, any exception while processing any exhibit component caused exhibit to die without rendering other elements.  This is inconsistent with typical browser "best effort" behavior to render every dom element that it can, which is more forgiving of unskilled developers.  I've modified exhibit to catch and warn instead of halting when one specific exhibit component cannot be configured for a dom node.

Possibly even better would be to render an error message into the offending dom node, to show the user where something went wrong.
