### PR TITLE
Modified exhibit to properly handle asynchronous item loading.  

### DIFF
--- a/scripted/src/scripts/data/database/local.js
+++ b/scripted/src/scripts/data/database/local.js
@@ -97,7 +97,7 @@ Exhibit.Database._LocalImpl.prototype.loadLinks = function() {
  * @param {Object} o An object that reflects the Exhibit JSON form.
  * @param {String} baseURI The base URI for normalizing URIs in the object.
  */
-Exhibit.Database._LocalImpl.prototype.loadData = function(o, baseURI) {
+Exhibit.Database._LocalImpl.prototype.loadData = function(o, baseURI, finish) {
     if (typeof o === "undefined" || o === null) {
         throw new Error(Exhibit._("%database.error.unloadable"));
     }
@@ -111,7 +111,9 @@ Exhibit.Database._LocalImpl.prototype.loadData = function(o, baseURI) {
         this.loadProperties(o.properties, baseURI);
     }
     if (typeof o.items !== "undefined") {
-        this.loadItems(o.items, baseURI);
+        this.loadItems(o.items, baseURI, finish);
+    } else {
+        finish();
     }
 };
 
@@ -264,6 +266,7 @@ Exhibit.Database._LocalImpl._loadChunked = function(worker, data, size, timeout,
     chunker = function() {
         var remnant, currentSize;
         remnant = length - index;
+        Exhibit.UI.busyMessage(remnant + " items");
         currentSize = (remnant >= size) ? size : remnant;
         if (index < length) {
             while (currentSize-- > 0) {
@@ -283,10 +286,16 @@ Exhibit.Database._LocalImpl._loadChunked = function(worker, data, size, timeout,
  * @param {Object} itemEntries The "items" subsection of Exhibit JSON.
  * @param {String} baseURI The base URI for normalizing URIs in the object.
  */
-Exhibit.Database._LocalImpl.prototype.loadItems = function(itemEntries, baseURI) {
+Exhibit.Database._LocalImpl.prototype.loadItems = function(itemEntries, baseURI, finish) {
+    var self, lastChar, indexTriple, wrapFinish, loader;
     Exhibit.jQuery(document).trigger("onBeforeLoadingItems.exhibit");
-    var self, lastChar, indexTriple, finish, loader;
+    Exhibit.UI.busyMessage('items');
     self = this;
+    wrapFinish = function() {
+        self._propertyArray = null;
+        Exhibit.jQuery(document).trigger("onAfterLoadingItems.exhibit");
+        finish();
+    };
     try {
         lastChar = baseURI.substr(baseURI.length - 1);
         if (lastChar === "#") {
@@ -295,10 +304,6 @@ Exhibit.Database._LocalImpl.prototype.loadItems = function(itemEntries, baseURI)
             baseURI += "/";
         }
         indexTriple = function(s,p,o) { self.addStatement(s,p,o); };
-        finish = function() {
-            self._propertyArray = null;
-            Exhibit.jQuery(document).trigger("onAfterLoadingItems.exhibit");
-        };
 
         loader = function(item) {
             if (typeof item === "object") {
@@ -306,9 +311,11 @@ Exhibit.Database._LocalImpl.prototype.loadItems = function(itemEntries, baseURI)
             }
         };
 
-        Exhibit.Database._LocalImpl._loadChunked(loader, itemEntries, 500, 10, finish);
+        Exhibit.Database._LocalImpl
+            ._loadChunked(loader, itemEntries, 1000, 10, wrapFinish);
     } catch(e) {
         Exhibit.Debug.exception(e, Exhibit._("%database.error.loadItemsFailure"));
+        wrapFinish();
     }
 };
 

--- a/scripted/src/scripts/data/importer.js
+++ b/scripted/src/scripts/data/importer.js
@@ -118,7 +118,17 @@ Exhibit.Importer.prototype.isRegistered = function() {
  * @param {Function} callback
  */
 Exhibit.Importer.prototype.load = function(link, database, callback) {
-    var resolver, url, postLoad, postParse, self;
+    var resolver, url, postLoad, postParse, self, finished = false
+    , finish = function () {
+        if (finished) {
+            return; //prevent duplicate calls
+        }
+        finished = true;
+        Exhibit.UI.hideBusyIndicator();
+        if (typeof callback === "function") {
+            callback();
+        }
+    };
     url = typeof link === "string" ? link : Exhibit.jQuery(link).attr("href");
     url = Exhibit.Persistence.resolveURL(url);
 
@@ -136,29 +146,28 @@ Exhibit.Importer.prototype.load = function(link, database, callback) {
 
     postParse = function(o) {
         try {
-            database.loadData(o, Exhibit.Persistence.getBaseURL(url));
+            Exhibit.UI.busyMessage('inserting');
+            database.loadData(o, Exhibit.Persistence.getBaseURL(url), finish);
         } catch(e) {
             Exhibit.Debug.exception(e);
             Exhibit.jQuery(document).trigger("error.exhibit", [e, Exhibit._("%import.couldNotLoad", url)]);
-        } finally {
-            if (typeof callback === "function") {
-                callback();
-            }
+            finish();
         }
     };
 
     self = this;
     postLoad = function(s, textStatus, jqxhr) {
         try {
+            Exhibit.UI.busyMessage('parsing');
             self._parse(url, s, postParse, link);
         } catch(e) {
+            finish();
             Exhibit.jQuery(document).trigger("error.exhibit", [e, Exhibit._("%import.couldNotParse", url)]);
-        } finally {
-            Exhibit.UI.hideBusyIndicator();
         }
     };
 
     Exhibit.UI.showBusyIndicator();
+    Exhibit.UI.busyMessage('fetching');
     resolver(url, database, postLoad, link);
 };
 

--- a/scripted/src/scripts/ui/ui.js
+++ b/scripted/src/scripts/ui/ui.js
@@ -393,7 +393,7 @@ Exhibit.UI._busyIndicatorCount = 0;
 /**
  * @static
  */
-Exhibit.UI.showBusyIndicator = function() {
+Exhibit.UI.showBusyIndicator = function(msg) {
     var scrollTop, height, top;
 
     Exhibit.UI._busyIndicatorCount++;
@@ -419,7 +419,17 @@ Exhibit.UI.showBusyIndicator = function() {
     
     Exhibit.jQuery(Exhibit.UI._busyIndicator).css("top", top + "px");
     Exhibit.jQuery(document.body).append(Exhibit.UI._busyIndicator);
+    if (msg) {
+        Exhibit.UI._busyIndicator.find('.message').text(msg);
+    }
 };
+
+Exhibit.UI.busyMessage = function(msg) {
+    msg = msg || "";
+    if (Exhibit.UI._busyIndicator) {
+        Exhibit.UI._busyIndicator.find('.message').text(msg);
+    }
+}
 
 /**
  * @static
@@ -432,6 +442,7 @@ Exhibit.UI.hideBusyIndicator = function() {
     
     try {
         Exhibit.UI._busyIndicator.remove();
+        Exhibit.UI._busyIndicator.find('.message').empty();
     } catch(e) {
         // silent
     }
@@ -762,6 +773,7 @@ Exhibit.UI.createBusyIndicator = function() {
     img = Exhibit.jQuery("<img />").attr("src", urlPrefix + "progress-running.gif");
     contentDiv.append(img);
     contentDiv.append(document.createTextNode(Exhibit._("%general.busyIndicatorMessage")));
+    contentDiv.append('<div class="message" style="font-size: x-small"/>');
     
     return containerDiv;
 };


### PR DESCRIPTION
In particular, exhibit assumed that when a call to loadItems returned,
items were done loading and exhibit could display.  With introduction
of chunked load this was no longer true, so exhibit was rendering with
incomplete data.  Now added a callback to item loader, to allow
exhibit loading to continue.

At same time, introduced a "message" functionality to the busy
indicator, allowing exhibit to indicate what it is doing at any time
that the busy indicator is displayed.
