### PR TITLE
2013 10 30 ordered view frame cache

### DIFF
--- a/scripted/src/scripts/ui/views/ordered-view-frame.js
+++ b/scripted/src/scripts/ui/views/ordered-view-frame.js
@@ -451,7 +451,7 @@ Exhibit.OrderedViewFrame.prototype._internalReconstruct = function(allItems) {
     
     processNonNumericLevel = function(items, index, values, valueType) {
         var compareKeys, k, key, vals
-        , retrieveRemove
+        , retrieveItems
         , keys = []
         , order = orders[index]
         , expr = order.forward ? "."+order.property : "!"+order.property


### PR DESCRIPTION
Performance optimization of ordered view frame, which is used to render lists of items in tile view and thumbnail view.  
1.  Used Exhibit.FacetUtilities.Cache to cache evaluation of all expressions used to sort the lists (so this utility is now used for views as well, and should become part of "expressionUtilities" or some such.
2.  Modified sorting algorithm to optimized for case where only the top k items are displayed: filters to top k items and sorts only those.
3.  Cleaned up some duplicate code.
