### PR TITLE
Allow extensions to load using standard script tags.

### DIFF
--- a/scripted/demos/presidents/presidents.html
+++ b/scripted/demos/presidents/presidents.html
@@ -14,7 +14,7 @@
     <link rel="exhibit-extension" type="text/javascript" href="../api/extensions/time/time-extension.js" />
     
     <!-- Replace the URL here with http://api.simile-widgets.org/exhibit/current/extensions/map/map-extension.js -->
-    <link rel="exhibit-extension" href="../api/extensions/map/map-extension.js"/>
+    <script src="../api/extensions/map/map-extension.js"/></script>
     
     <link rel='stylesheet' href='styles.css' type='text/css' />
   </head>

--- a/scripted/src/exhibit-api.js
+++ b/scripted/src/exhibit-api.js
@@ -431,6 +431,25 @@ Exhibit.generateDelayID = function() {
     return "delay" + Math.round(Math.random()*100000);
 };
 
+(function () {
+    var listeners = [], jQueryLoaded = false;
+    Exhibit.onjQueryLoaded = function(f) {
+        if (jQueryLoaded) {
+            f();
+        } else {
+            listeners.push(f);
+        }
+    };
+    Exhibit.triggerjQueryLoaded = function() {
+        var i;
+        for (i=0; i < listeners.length; i++) {
+            (listeners[i])();
+        }
+        jQueryLoaded = true;
+    }
+}());
+    
+
 /**
  * Load all scripts associated with Exhibit.
  * 

--- a/scripted/src/extensions/map/map-extension.js
+++ b/scripted/src/extensions/map/map-extension.js
@@ -18,7 +18,7 @@
  *    "http://api.simile-widgets.org"
  */
 
-(function() {
+Exhibit.onjQueryLoaded(function() {
     var loader;
     loader = function() {
         var javascriptFiles, cssFiles, paramTypes, url, scriptURLs, cssURLs, ajaxURLs, i, delayID, finishedLoading, localesToLoad
@@ -149,4 +149,4 @@
     };
 
     Exhibit.jQuery(document).one("loadExtensions.exhibit", loader);
-}());
+});

--- a/scripted/src/extensions/time/time-extension.js
+++ b/scripted/src/extensions/time/time-extension.js
@@ -29,7 +29,7 @@
  * load-simile-ajax.js.
  */
 
-(function() {
+Exhibit.onjQueryLoaded(function() {
     var loader;
     loader = function() {
         var javascriptFiles, cssFiles, paramTypes, url, scriptURLs, cssURLs, ajaxURLs, i, delayID, finishedLoading, localesToLoad
@@ -129,4 +129,4 @@
     };
 
     Exhibit.jQuery(document).one("loadExtensions.exhibit", loader);
-}());
+});

--- a/scripted/src/scripts/exhibit.js
+++ b/scripted/src/scripts/exhibit.js
@@ -12,6 +12,7 @@
     if (!Exhibit._jQueryExists) {
         jQuery.noConflict();
     }
+    Exhibit.triggerjQueryLoaded();
 }());
 
 /**


### PR DESCRIPTION
Several people have run into trouble switching to exhibit 3 because of the change to using link tags to load extensions.  So, I've modified exhibit (and the two main extensions, map and timeline) to work if they are included as scripts instead of links.  Links continue to work as well.  This involved a little bit of messy code on exhibit-api.js and exhibit.js , but I think it's worth it to permit easier transition to E3.
