### PR TITLE
Bug fixes in the image and URL formatters

### DIFF
--- a/scripted/src/scripts/ui/formatter.js
+++ b/scripted/src/scripts/ui/formatter.js
@@ -313,7 +313,7 @@ Exhibit.Formatter._URLFormatter = function(uiContext) {
  * @param {Function} appender
  */
 Exhibit.Formatter._URLFormatter.prototype.format = function(value, appender) {
-    var a = Exhibit.jQuery("a").attr("href", value).html(value);
+    var a = Exhibit.jQuery("<a>").attr("href", value).html(value);
     
     if (this._target !== null) {
         a.attr("target", this._target);


### PR DESCRIPTION
The image formatter had a minor typo that would cause all tooltips to be blank.  The URL formatter had a jquery selection error that cause all links in the page to be modified and moved.
