### PR TITLE
fixed get subjects from objects, wasn't working before because wrong arr...

### DIFF
--- a/scripted/src/scripts/data/database/local.js
+++ b/scripted/src/scripts/data/database/local.js
@@ -603,7 +603,7 @@ Exhibit.Database._LocalImpl.prototype.getObject = function(s, p) {
 Exhibit.Database._LocalImpl.prototype.getSubject = function(o, p) {
     var s = null;
 
-    Exhibit.Database._indexVisit(this._spo, o, p, function (v) {
+    Exhibit.Database._indexVisit(this._ops, o, p, function (v) {
         s=v;
         return false; //terminate iteration
     });


### PR DESCRIPTION
...ay was used

Fixed a tiny bug about getting objects from subjects. It wasn't working before because the subject list was used instead of the object list.
