### PR TITLE
Correction to the Hierarchical Facet to prevent duplicate entries in the...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store?
 Icon?
 Thumbs.db
+.idea

--- a/scripted/src/scripts/ui/facets/hierarchical-facet.js
+++ b/scripted/src/scripts/ui/facets/hierarchical-facet.js
@@ -711,6 +711,21 @@ Exhibit.HierarchicalFacet.prototype._buildCache = function() {
                 map[x] = [ y ];
             }
         };
+
+        inMap = function (x, y, map) {
+            var yValues
+            if (typeof map[x] == "undefined") {
+                return false;
+            } else {
+                yValues = map[x];
+                for (i = 0; i < yValues.length; i++) {
+                    if (yValues[i] == y) {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
         
         database = this.getUIContext().getDatabase();
         tree = {
@@ -745,8 +760,10 @@ Exhibit.HierarchicalFacet.prototype._buildCache = function() {
                 results = groupingExpression.evaluateOnItem(value, database);
                 if (results.values.size() > 0) {
                     results.values.visit(function(parentValue) {
-                        insert(value, parentValue, valueToParent);
-                        insert(parentValue, value, valueToChildren);
+                        if (!inMap(value,parentValue,valueToParent)) {
+                            insert(value, parentValue, valueToParent);}
+                        if (!inMap(parentValue,value,valueToChildren)) {
+                            insert(parentValue, value, valueToChildren);}
                         if (!valueSet.contains(parentValue)) {
                             newValueSet.add(parentValue);
                         }


### PR DESCRIPTION
This fix corrects a problem where duplicate entries appear in the Hierarchical Facet. The problem is dataset dependent and more likely to happen with a larger dataset (as opposed to the small set in the demo, where it doesn't happen).
