### PR TITLE
Fixed a bug with the data-ex-collection-id attribute.

### DIFF
--- a/scripted/src/scripts/exhibit.js
+++ b/scripted/src/scripts/exhibit.js
@@ -118,7 +118,19 @@ Exhibit.getAttribute = function(elmt, name, splitOn) {
         if (typeof value === "undefined" || value.length === 0) {
             value = Exhibit.jQuery(elmt).attr("data-ex-"+hyphenate(name));
             if (typeof value === "undefined" || value.length === 0) {
-                return null;
+                if  ((name[name.length-2]==="I") &&
+                     (name[name.length-1]==="D")) {
+                    //Hack: some exhibit attributes end with "ID"
+                    //e.g. collectionID
+                    //this gets hyphenated as collection-i-d
+                    //but the "right" hyphenation is collection-id
+                    //permit either for compatibility
+                    name = hyphenate(name.slice(0,-1)+"d");
+                    value = Exhibit.jQuery(elmt).attr("data-ex-"+name);
+                    if (typeof value === "undefined" || value.length === 0) {
+                        return null;
+                    }
+                }
             }
         }
         if (typeof value.toString !== "undefined") {


### PR DESCRIPTION
Exhibit's default mapping of the (camelCase) collectionID parameter to html was seeking an html attribute called data-ex-collection-i-d .  So I added a hack that specifically looks for parameters ending in
(capital) ID and looks for the -id mapping of the parameter.
