### PR TITLE
Modified exhibit parser to ignore the (unprefixed) "role" attribute

### DIFF
--- a/scripted/src/scripts/exhibit.js
+++ b/scripted/src/scripts/exhibit.js
@@ -114,7 +114,12 @@ Exhibit.getAttribute = function(elmt, name, splitOn) {
     };
     
     try {
-        value = Exhibit.jQuery(elmt).attr(name);
+        if (name !== "role") {
+            //role is now an official html5 attribute
+            //so if exhibit accepts it, then
+            //exhibit will incorrectly hit non-exhibit items
+            value = Exhibit.jQuery(elmt).attr(name);
+            }
         if (typeof value === "undefined" || value.length === 0) {
             value = Exhibit.jQuery(elmt).attr("data-ex-"+hyphenate(name));
             if (typeof value === "undefined" || value.length === 0) {


### PR DESCRIPTION
because role has been defined as an official attribute in html5 (from
ARIA) and is appearing in many places where it will confuse exhibit.
