### PR TITLE
Map and timeline now check for "dev" setting. If active, load unbundled scripts.

### DIFF
--- a/scripted/src/exhibit-api.js
+++ b/scripted/src/exhibit-api.js
@@ -72,7 +72,8 @@ var Exhibit = {
         "babel": undefined,
         "backstage": undefined,
         "locale": undefined,
-        "persist": true
+        "persist": true,
+        "dev": false
     },
 
     /**
@@ -481,7 +482,8 @@ Exhibit.load = function() {
         "babel": String,
         "backstage": String,
         "locale": String,
-        "persist": Boolean
+        "persist": Boolean,
+        "dev": Boolean
     };
 
     if (typeof Exhibit_urlPrefix === "string") {
@@ -511,6 +513,7 @@ Exhibit.load = function() {
                 if ((arg.length === 2) &&
                     (arg[0]==="exhibit-dev") &&
                     (arg[1]==="true")) {
+                    Exhibit.params.dev = true;
                     Exhibit.params.bundle = false;
                     Exhibit.params.persist = false;
                 }

--- a/scripted/src/extensions/map/map-extension.js
+++ b/scripted/src/extensions/map/map-extension.js
@@ -69,6 +69,10 @@ Exhibit.onjQueryLoaded(function() {
             "mapPrefix": String
         };
         
+        if (Exhibit.params.dev) {
+            Exhibit.MapExtension.params.bundle = false;
+        }
+
         if (typeof Exhibit_MapExtension_urlPrefix === "string") {
             Exhibit.MapExtension.urlPrefix = Exhibit_MapExtension_urlPrefix;
             if (typeof Exhibit_MapExtension_parameters !== "undefined") {

--- a/scripted/src/extensions/time/time-extension.js
+++ b/scripted/src/extensions/time/time-extension.js
@@ -69,6 +69,10 @@ Exhibit.onjQueryLoaded(function() {
             "timelinePrefix": String,
             "timelineVersion": String
         };
+
+        if (Exhibit.params.dev) {
+            Exhibit.TimeExtension.params.bundle = false;
+        }
         
         if (typeof Exhibit_TimeExtension_urlPrefix === "string") {
             Exhibit.TimeExtension.urlPrefix = Exhibit_TimeExtension_urlPrefix;


### PR DESCRIPTION
Added "dev" parameter to exhibit (set by exhibit-dev=true url argument).