### PR TITLE
Support for date formatting in the slider facet

### DIFF
--- a/scripted/src/scripts/ui/facets/slider-facet.js
+++ b/scripted/src/scripts/ui/facets/slider-facet.js
@@ -31,6 +31,7 @@ Exhibit.SliderFacet._settingSpecs = {
     "horizontal":       { "type": "boolean", "defaultValue": true },
     "showMissing":      { "type": "boolean", "defaultValue": true},
     "inputText":        { type: "boolean", defaultValue: true },
+    "displayFormat":    { type: "text", defaultValue: "none" },
     "selection":        { "type": "float", "dimensions": 2}
 };
 

--- a/scripted/src/scripts/ui/facets/slider.js
+++ b/scripted/src/scripts/ui/facets/slider.js
@@ -152,8 +152,21 @@ Exhibit.SliderFacet.slider.prototype._setDisplays = function(slider) {
         this._dom.minDisplay.val(min);
         this._dom.maxDisplay.val(max);
     } else {
-        this._dom.minDisplay.html(min);
-        this._dom.maxDisplay.html(max);
+	if (this._facet._settings.displayFormat !== "none" && this._facet.hasUIContext()) {
+	    var minDisplay = this._dom.minDisplay;
+	    var maxDisplay = this._dom.maxDisplay;
+	    this._facet
+		.getUIContext()
+		.format(min, this._facet._settings.displayFormat,
+			function(value) { minDisplay.html(value); });
+	    this._facet
+		.getUIContext()
+		.format(max, this._facet._settings.displayFormat,
+			function(value) { maxDisplay.html(value); });
+	} else {
+	    this._dom.minDisplay.html(min);
+            this._dom.maxDisplay.html(max);
+	}
     }
 };
 

--- a/scripted/src/scripts/ui/formatter.js
+++ b/scripted/src/scripts/ui/formatter.js
@@ -557,7 +557,12 @@ Exhibit.Formatter._DateFormatter.prototype.format = function(value, appender) {
  */
 Exhibit.Formatter._DateFormatter.prototype.formatText = function(value) {
     var date, text, segments, i, segment;
-    date = (value instanceof Date) ? value : Exhibit.DateTime.parseIso8601DateTime(value);
+    if (value instanceof Date)
+	date = value;
+    else if (typeof value === "number")
+	date = new Date(value);
+    else
+	date = Exhibit.DateTime.parseIso8601DateTime(value);
     if (typeof date === "undefined" || date === null) {
         return value;
     }


### PR DESCRIPTION
I'm not sure if this is the best way to do this, but here's a small patch that allows the slider facet to display dates in leu of "ms past the epoch".  E.g.:

![screen-capture-5](https://cloud.githubusercontent.com/assets/4621169/7311528/81b26210-ea0b-11e4-9963-38618d476c51.png)

If this fits in with your design and roadmap, I'm sure I could add text input support as well.