### PR TITLE
Create Accessor for Field Separated by Commas

### DIFF
--- a/scripted/src/scripts/util/settings.js
+++ b/scripted/src/scripts/util/settings.js
@@ -363,7 +363,11 @@ Exhibit.SettingsUtilities._createTupleAccessor = function(f, spec) {
 Exhibit.SettingsUtilities._createElementalAccessor = function(f, spec) {
     var value, bindingType, expression, parser;
 
-    value = f(spec.attributeName);
+    if (typeof spec.attributeName == 'function'){
+            value = spec.attributeName();
+    } else{
+        value = f(spec.attributeName);
+    }
 
     if (typeof value === "undefined" || value === null) {
         return null;


### PR DESCRIPTION
Handles cases where attributeName is a function; used when field is separated by commas.  Currently used by Bar Chart View's "values" field for stacking.