### PR TITLE
Typo with scrollwheel spelling

### DIFF
--- a/scripted/src/extensions/map/scripts/map-view.js
+++ b/scripted/src/extensions/map/scripts/map-view.js
@@ -462,7 +462,7 @@ Exhibit.MapView.prototype._constructGMap = function(mapDiv) {
 
 	    if (typeof settings.scrollWheelZoom !== "undefined" &&
             !settings.scrollWheelZoom) {
-	        mapOptions.scrollWheel = false;
+	        mapOptions.scrollwheel = false;
         }
 
         switch (settings.type) {


### PR DESCRIPTION
`scrollWheel` is not the correct spelling for this option. It must be `scrollwheel`. See `MapOptions` documentation at https://developers.google.com/maps/documentation/javascript/3.22/reference

If not the `data-ex-scroll-wheel-zoom=false` option doesn't work with map views.