### PR TITLE
Update tsv-csv.js (trim after split)

### DIFF
--- a/scripted/src/scripts/data/importers/tsv-csv.js
+++ b/scripted/src/scripts/data/importers/tsv-csv.js
@@ -114,6 +114,8 @@ Exhibit.Importer.TsvCsv._parseInternal = function(text, separator, expressionStr
 	    if (row[j].length>0) {
 		if (valueSeparator && (row[j].indexOf(valueSeparator) >= 0)) {
 		    row[j]=row[j].split(valueSeparator);
+		    row[j]=row[j].reduce( function (prev, cur) { 
+ +		    	if ((cur = cur.trim()).length > 0){ prev.push(cur);} return prev;},[]);
 		}
 		item[propNames[j]]=row[j];
 	    }


### PR DESCRIPTION
Trim after split. If not 'a,b,c' aren't the same values than 'a, b  , c'.
Removed arrow function.