### PR TITLE
added API Key data attr for map extension

### DIFF
--- a/scripted/demos/cities/cities.html
+++ b/scripted/demos/cities/cities.html
@@ -11,7 +11,7 @@
     <script src="../api/exhibit-api.js"></script>
     
     <!-- Replace the URL here with http://api.simile-widgets.org/exhibit/current/extensions/map/map-extension.js -->
-    <link rel="exhibit-extension" href="../api/extensions/map/map-extension.js"/>
+    <link rel="exhibit-extension" href="../api/extensions/map/map-extension.js" data-apikey="AIzaSyCDO3EXWKJms5T38db48czFJZDunhYIzn8" />
   </head>
   <body>
     <ul id="path">
@@ -37,7 +37,7 @@
            data-ex-label="Cities"
            data-ex-latlng=".latlng"
            data-ex-size-key=".pop"
-	   data-ex-pin="false"
+     data-ex-pin="false"
            data-ex-size-coder="pop-coder"
            data-ex-size-legend-label="Population"
            data-ex-center="38.62756, -90.19896"

--- a/scripted/src/extensions/map/map-extension.js
+++ b/scripted/src/extensions/map/map-extension.js
@@ -99,23 +99,25 @@ Exhibit.onjQueryLoaded(function() {
         
         scriptURLs = [];
         cssURLs = [];
+        var APIKey = Exhibit.jQuery('[data-apikey]').data("apikey")
+        console.log("Exhibit | Map extension: APIKey = " + APIKey)
         if (Exhibit.MapExtension.params.service === "google2" &&
                    typeof GMap2 === "undefined") {
             if (typeof Exhibit.params.gmapKey !== "undefined") {
-	            scriptURLs.push(proto + "//maps.google.com/maps?file=api&v=2&sensor=false&callback=Exhibit.MapExtension.gmapCallback&async=2&key=" + Exhibit.params.gmapKey);
+                scriptURLs.push(proto + "//maps.google.com/maps?key=" + APIKey + "&callback=Exhibit.MapExtension.gmapCallback&async=2" + Exhibit.params.gmapKey);
             } else if (typeof Exhibit.MapExtension.params.gmapKey !== "undefined") {
-	            scriptURLs.push(proto + "//maps.google.com/maps?file=api&v=2&sensor=false&callback=Exhibit.MapExtension.gmapCallback&async=2&key=" + Exhibit.MapExtension.params.gmapKey);
+                scriptURLs.push(proto + "//maps.google.com/maps?key=" + APIKey + "&callback=Exhibit.MapExtension.gmapCallback&async=2" + Exhibit.MapExtension.params.gmapKey);
             } else {
-	            scriptURLs.push(proto + "//maps.google.com/maps?file=api&v=2&sensor=false&callback=Exhibit.MapExtension.gmapCallback&async=2");
+                scriptURLs.push(proto + "//maps.google.com/maps?key=" + APIKey + "&callback=Exhibit.MapExtension.gmapCallback&async=2");
             }
             if (!Exhibit.MapExtension.params.bundle) {
                 javascriptFiles.push("google-maps-v2-view.js");
             }
         } else {
             // if author is referring to an unknown service, default to google
-	        if (typeof google === "undefined" ||
+            if (typeof google === "undefined" ||
                 (typeof google !== "undefined" && typeof google.map === "undefined")) {
-	            scriptURLs.push(proto + "//maps.googleapis.com/maps/api/js?sensor=false&callback=Exhibit.MapExtension.gmapCallback");
+                scriptURLs.push(proto + "//maps.googleapis.com/maps/api/js?key=" + APIKey + "&callback=Exhibit.MapExtension.gmapCallback");
                 if (!Exhibit.MapExtension.params.bundle) {
                     javascriptFiles.push("map-view.js");
                 }

--- a/scripted/src/scripts/util/facets.js
+++ b/scripted/src/scripts/util/facets.js
@@ -90,7 +90,7 @@ Exhibit.FacetUtilities.toggleCollapse = function(dom, facet) {
  */
 Exhibit.FacetUtilities.isCollapsed = function(facet) {
     var el = facet._dom.frameDiv;
-    return !Exhibit.jQuery(el).is(":visible");
+    return !Exhibit.jQuery(el).is(":visible") && Exhibit.jQuery(el).attr("ex-collapsible"); //fixes visibility / collapsibility issue
 };
 
 /**


### PR DESCRIPTION
To include an API key, use the new _data-apikey_ attribute of the link tag in which points to the map extension:

`<link rel="exhibit-extension" href="../api/extensions/map/map-extension.js" data-apikey="YOURAPIKEY" />`

See the Cities demo in the updated code for an example (Exhibit/scripted/demos/cities/cities.html)